### PR TITLE
update rust impl specification compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Here's an example of a TypeID of type `user`:
 | -------- | ------ | ---------------------- |
 | [C# (.Net)](https://github.com/TenCoKaciStromy/typeid-dotnet) | @TenCoKaciStromy | Not Yet |
 | [Rust](https://github.com/alisa101rs/typeid-rs) | @alisa101rs | Not Yet |
-| [Rust](https://github.com/conrad/type-safe-id) | @conrad | Not Yet |
+| [Rust](https://github.com/conrad/type-safe-id) | @conradludgate | Yes |
 | [Swift](https://github.com/Frizlab/swift-typeid) | @Frizlab | Not Yet |
 | [TypeScript](https://github.com/ongteckwu/typeid-ts) | @ongteckwu | Not Yet |
 


### PR DESCRIPTION
Specification tests have been added to the Rust implementation of type-safe-id <https://github.com/conradludgate/type-safe-id/blob/main/tests/spec.rs>.

There are 2 missing failure tests from this regarding uppercase and ambiguous case Crockford encodings. This is correct according to Crockford where you should accept ambiguous inputs after converting them.