### PR TITLE
Add `BombenProdukt/typeid` for `PHP` to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Implementations should adhere to the formal [specification](./spec).
 | Language | Author | Validated Against Spec? |
 | -------- | ------ | ---------------------- |
 | [C# (.Net)](https://github.com/TenCoKaciStromy/typeid-dotnet) | @TenCoKaciStromy | Not Yet |
+| [PHP](https://github.com/BombenProdukt/typeid) | [@BombenProdukt](https://github/BombenProdukt) | Yes, on 2023-07-03 |
 | [Python](https://github.com/akhundMurad/typeid-python) | @akhundMurad | Yes, 2023-06-30 |
 | [Ruby](https://github.com/broothie/typeid-ruby) | [@broothie](https://github.com/broothie) | Yes, on 2023-06-30 |
 | [Rust](https://github.com/alisa101rs/typeid-rs) | @alisa101rs | Not Yet |


### PR DESCRIPTION
I've begun an implementation for PHP, which you can find at https://github.com/BombenProdukt/typeid. The encoding and decoding implementation is based on https://github.com/jetpack-io/typeid-js. At present, it passes all encodings as per https://github.com/jetpack-io/typeid/blob/main/spec/valid.yml. We are running the tests directly against the `valid.yml` and `invalid.yml` files to promptly detect any failures. ~Tests for the `invalid.yml` file are still missing, but I plan to add them in the coming days as time allows.~